### PR TITLE
Wire up reading file for signing command

### DIFF
--- a/command_sign.go
+++ b/command_sign.go
@@ -38,6 +38,7 @@ func commandSign() error {
 		return errors.Wrap(err, "failed to get idenity signer")
 	}
 
+	var f io.ReadCloser
 	if len(fileArgs) == 1 {
 		if f, err = os.Open(fileArgs[0]); err != nil {
 			return errors.Wrapf(err, "failed to open message file (%s)", fileArgs[0])

--- a/command_sign.go
+++ b/command_sign.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/mastahyeti/certstore"
@@ -37,8 +38,17 @@ func commandSign() error {
 		return errors.Wrap(err, "failed to get idenity signer")
 	}
 
+	if len(fileArgs) == 1 {
+		if f, err = os.Open(fileArgs[0]); err != nil {
+			return errors.Wrapf(err, "failed to open message file (%s)", fileArgs[0])
+		}
+		defer f.Close()
+	} else {
+		f = stdin
+	}
+
 	dataBuf := new(bytes.Buffer)
-	if _, err = io.Copy(dataBuf, stdin); err != nil {
+	if _, err = io.Copy(dataBuf, f); err != nil {
 		return errors.Wrap(err, "failed to read message from stdin")
 	}
 


### PR DESCRIPTION
A fix for https://github.com/github/smimesign/issues/50
Add logic to read file from command line for signing command in parallel to verify command.