### PR TITLE
Root certs are not used on Windows

### DIFF
--- a/command_verify.go
+++ b/command_verify.go
@@ -7,10 +7,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
+	"unsafe"
 
-	"github.com/certifi/gocertifi"
 	"github.com/mastahyeti/cms"
 	"github.com/pkg/errors"
+)
+
+const (
+	CRYPT_E_NOT_FOUND = 0x80092004
 )
 
 func commandVerify() error {
@@ -165,20 +170,32 @@ func verifyDetached() error {
 }
 
 func verifyOpts() x509.VerifyOptions {
-	roots, err := x509.SystemCertPool()
+	roots := x509.NewCertPool()
+	storeHandle, err := syscall.CertOpenSystemStore(0, syscall.StringToUTF16Ptr("Root"))
 	if err != nil {
-		// SystemCertPool isn't implemented for Windows. fall back to mozilla trust
-		// store.
-		roots, err = gocertifi.CACerts()
-		if err != nil {
-			// Fall back to an empty store. Verification will likely fail.
-			roots = x509.NewCertPool()
-		}
+		fmt.Println(syscall.GetLastError())
 	}
 
-	for _, ident := range idents {
-		if cert, err := ident.Certificate(); err == nil {
-			roots.AddCert(cert)
+	var cert *syscall.CertContext
+	for {
+		cert, err = syscall.CertEnumCertificatesInStore(storeHandle, cert)
+		if err != nil {
+			if errno, ok := err.(syscall.Errno); ok {
+				if errno == CRYPT_E_NOT_FOUND {
+					break
+				}
+			}
+			fmt.Println(syscall.GetLastError())
+		}
+		if cert == nil {
+			break
+		}
+		// Copy the buf, since ParseCertificate does not create its own copy.
+		buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:]
+		buf2 := make([]byte, cert.Length)
+		copy(buf2, buf)
+		if c, err := x509.ParseCertificate(buf2); err == nil {
+			roots.AddCert(c)
 		}
 	}
 


### PR DESCRIPTION
The implementation of the verify command fails to read from the system root store on Windows. This was likely done due to issues with the x509 library which fails to parse the root store as detailed in [Issue #16736](https://github.com/golang/go/issues/16736) of the golang crypto library. Windows instead was defaulting to the gocertifi library, which prevents users from adding or removing trusted roots, and verifying signatures against those roots. 

In the golang crypto issue referenced before, there is a workaround which enables us to parse the root store and verify signatures against these roots. I have adopted this fix to this project. 

All tests passing.

Thanks to @ndouthit for help in troubleshooting this issue. 