### PR TITLE
Update tests to allow chains in any order. Fixes #68.

### DIFF
--- a/command_sign_test.go
+++ b/command_sign_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func chainContains(chain []*x509.Certificate, want *x509.Certificate) bool {
+	for _, cert := range chain {
+		if cert.Equal(want) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestSign(t *testing.T) {
 	defer testSetup(t, "--sign", "-u", certHexFingerprint(leaf.Certificate))()
 
@@ -37,8 +46,8 @@ func TestSignIncludeCertsAIA(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(certs))
-	require.True(t, certs[0].Equal(aiaLeaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
+	require.True(t, chainContains(certs, aiaLeaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
 }
 
 func TestSignIncludeCertsDefault(t *testing.T) {
@@ -57,8 +66,8 @@ func TestSignIncludeCertsDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
 }
 
 func TestSignIncludeCertsMinus3(t *testing.T) {
@@ -77,8 +86,8 @@ func TestSignIncludeCertsMinus3(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
 }
 
 func TestSignIncludeCertsMinus2(t *testing.T) {
@@ -97,8 +106,8 @@ func TestSignIncludeCertsMinus2(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
 }
 
 func TestSignIncludeCertsMinus1(t *testing.T) {
@@ -117,9 +126,9 @@ func TestSignIncludeCertsMinus1(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 3, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
-	require.True(t, certs[2].Equal(ca.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
+	require.True(t, chainContains(certs, ca.Certificate))
 }
 
 func TestSignIncludeCerts0(t *testing.T) {
@@ -156,7 +165,7 @@ func TestSignIncludeCerts1(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
 }
 
 func TestSignIncludeCerts2(t *testing.T) {
@@ -175,8 +184,8 @@ func TestSignIncludeCerts2(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
 }
 
 func TestSignIncludeCerts3(t *testing.T) {
@@ -195,9 +204,9 @@ func TestSignIncludeCerts3(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 3, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
-	require.True(t, certs[2].Equal(ca.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
+	require.True(t, chainContains(certs, ca.Certificate))
 }
 
 func TestSignIncludeCerts4(t *testing.T) {
@@ -216,7 +225,7 @@ func TestSignIncludeCerts4(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 3, len(certs))
-	require.True(t, certs[0].Equal(leaf.Certificate))
-	require.True(t, certs[1].Equal(intermediate.Certificate))
-	require.True(t, certs[2].Equal(ca.Certificate))
+	require.True(t, chainContains(certs, leaf.Certificate))
+	require.True(t, chainContains(certs, intermediate.Certificate))
+	require.True(t, chainContains(certs, ca.Certificate))
 }


### PR DESCRIPTION
The chain in question is defined in RFC5652 as a CertificateSet, which is a `SET OF` certs:

- https://tools.ietf.org/html/rfc5652#section-5.1
- https://tools.ietf.org/html/rfc5652#section-10.2.3

Go 1.15 introduced a change that sorts such sets: https://go.googlesource.com/go/+/f0cea848679b8f8cdc5f76e1b1e36ebb924a68f8

Our tests were implicitly relying on the sets to stay in the order we order we create them (leaf then intermediate then root, or a truncated subset of those), but the right thing to do at this point is update our tests.