### PR TITLE
switch to SecTrustEvaulateWihError to avoid deprecation warning

### DIFF
--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -160,8 +160,9 @@ func (i *macIdentity) CertificateChain() ([]*x509.Certificate, error) {
 	}
 	defer C.CFRelease(C.CFTypeRef(trustRef))
 
+	_ = C.SecTrustEvaluateWithError(trustRef, &nilCFErrorRef)
 	var status C.SecTrustResultType
-	if err := osStatusError(C.SecTrustEvaluate(trustRef, &status)); err != nil {
+	if err := osStatusError(C.SecTrustGetTrustResult(trustRef, &status)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Hi there! Building smimesign or certstore currently displays a deprecation warning (#85):

```
# github.com/github/smimesign/certstore
cgo-gcc-prolog:473:11: warning: 'SecTrustEvaluate' is deprecated: first deprecated in macOS 10.15 [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h:353:10: note: 'SecTrustEvaluate' has been explicitly marked deprecated here
```

I dove into this and this is what I came up with.

`SecTrustEvaluate` has been marked as deprecated and should be replaced by `SecTrustEvaluateWithError` according to https://developer.apple.com/documentation/security/1394363-sectrustevaluate

The new function, `SecTrustEvaluateWithError` returns a bool if the certificate is trusted or not, which I don't believe we care about or need here. It optionally takes a reference to a CFError as well, in which I pass in nil (but we could capture/parse it if we think it's necessary). According to the docs, to make a determination if the failure is recoverable, the docs say to make a call to `SecTrustGetTrustResult` and evaluate that `OSStatus` result. 

I've modified the code to call `SecTrustEvaluateWithError` followed by a call to `SecTrustGetTrustResult` and detemine if that error is recoverable or not. The tests are all passing and I haven't noticed any side effects other than the deprecation warning being gone :) 

Let me know if you think this is an acceptable PR!