### PR TITLE
Use appropriate digest algorithm during signature creation

### DIFF
--- a/ietf-cms/protocol/protocol.go
+++ b/ietf-cms/protocol/protocol.go
@@ -659,7 +659,7 @@ func (sd *SignedData) AddSignerInfo(chain []*x509.Certificate, signer crypto.Sig
 		return err
 	}
 
-	digestAlgorithmID := digestAlgorithmForPublicKey(pub)
+	digestAlgorithmID := digestAlgorithmForPublicKey(signer.Public())
 
 	signatureAlgorithmOID, ok := oid.X509PublicKeyAndDigestAlgorithmToSignatureAlgorithm[cert.PublicKeyAlgorithm][digestAlgorithmID.Algorithm.String()]
 	if !ok {


### PR DESCRIPTION
Pass the public key instead of the marshalled public key to
`digestAlgorithmForPublicKey` in `SignedData.AddSignerInfo`.

Previously, the marshalled public key was passed instead of the actual
public key. The result is that always SHA256 was being selected, even
for ECDSA where the hash algorithm should be selected based on the curve.