### PR TITLE
TrimSpace from string fingerprint before hex.DecodeString

### DIFF
--- a/command_sign_test.go
+++ b/command_sign_test.go
@@ -19,7 +19,7 @@ func chainContains(chain []*x509.Certificate, want *x509.Certificate) bool {
 }
 
 func TestSign(t *testing.T) {
-	defer testSetup(t, "--sign", "-u", certHexFingerprint(leaf.Certificate))()
+	defer testSetup(t, "-su " + certHexFingerprint(leaf.Certificate))()
 
 	stdinBuf.WriteString("hello, world!")
 	require.NoError(t, commandSign())

--- a/utils.go
+++ b/utils.go
@@ -17,6 +17,7 @@ func normalizeFingerprint(sfpr string) []byte {
 		return nil
 	}
 
+	sfpr = strings.TrimSpace(sfpr)
 	if strings.HasPrefix(sfpr, "0x") {
 		sfpr = sfpr[2:]
 	}


### PR DESCRIPTION
Rookie passing "-bsau [string fingerprint]" as one parameter when debugging. getopt still worked but didn't trim the leading space from string fingerprint.

The end of email parsing at https://github.com/github/smimesign/blob/3564e86011859c28b315328027abebb954b6bf6f/parse_user_id.go#L106 calls TrimSpaces everywhere so I thought it might be worth doing the same defensively for the string fingerprint.

PS. Both my 👍 👍 's up for pull [cgo windows to syscall #93](https://github.com/github/smimesign/pull/93) and @tg123, it's the only reason I'm here.