### PR TITLE
chore: remove git.io

### DIFF
--- a/parse_user_id.go
+++ b/parse_user_id.go
@@ -4,7 +4,8 @@ import "strings"
 
 // The following was copied from the crypto/openpgpg/packet package.
 
-// The original license can be found at https://git.io/vFFwQ
+// The original license can be found at
+// https://github.com/golang/crypto/blob/9f005a07e0d31d45e6656d241bb5c0f2efd4bc94/LICENSE
 //
 //     Copyright (c) 2009 The Go Authors. All rights reserved.
 //
@@ -34,7 +35,8 @@ import "strings"
 //     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 //     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// The orignal code can be found at https://git.io/vFFwX
+// The orignal code can be found at
+// https://github.com/golang/crypto/blob/9f005a07e0d31d45e6656d241bb5c0f2efd4bc94/openpgp/packet/userid.go#L89-L160
 //
 // parseUserID extracts the name, comment and email from a user id string that
 // is formatted as "Full Name (Comment) <email@example.com>".

--- a/status.go
+++ b/status.go
@@ -14,7 +14,8 @@ import (
 
 // This file implements gnupg's "status protocol". When the --status-fd argument
 // is passed, gpg will output machine-readable status updates to that fd.
-// Details on the "protocol" can be found at https://git.io/vFFKC
+// Details on the "protocol" can be found at
+// https://github.com/gpg/gnupg/blob/918792befd835e04b4043b9ce42ea6d829a284fa/doc/DETAILS#format-of-the-status-fd-output
 
 type status string
 


### PR DESCRIPTION
Fixes #110.

---

All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/