### PR TITLE
Port fix to compile on linux in new repo

### DIFF
--- a/certstore/certstore_linux.go
+++ b/certstore/certstore_linux.go
@@ -2,12 +2,6 @@ package certstore
 
 import "errors"
 
-// This will hopefully give a compiler error that will hint at the fact that
-// this package isn't designed to work on Linux.
-func init() {
-	CERTSTORE_DOESNT_WORK_ON_LINIX
-}
-
 // Implement this function, just to silence other compiler errors.
 func openStore() (Store, error) {
 	return nil, errors.New("certstore only works on macOS and Windows")


### PR DESCRIPTION
We had ported a fix to our fork https://github.com/brexhq/certstore/commit/082166f0d6bbaa2d71268730a5f8295937085ca7
that allows us to compile certstore dep on linux. With the newer repo
we are doing the same now so we can port over to the new repo