### PR TITLE
Fix timestamp response buffer allocation if response size is unknown.

### DIFF
--- a/ietf-cms/timestamp/timestamp.go
+++ b/ietf-cms/timestamp/timestamp.go
@@ -101,7 +101,10 @@ func (req Request) Do(url string) (Response, error) {
 		return nilResp, fmt.Errorf("Bad content-type: %s", ct)
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, httpResp.ContentLength))
+	buf := new(bytes.Buffer)
+	if httpResp.ContentLength > 0 {
+		buf = bytes.NewBuffer(make([]byte, 0, httpResp.ContentLength))
+	}
 	if _, err = io.Copy(buf, httpResp.Body); err != nil {
 		return nilResp, err
 	}


### PR DESCRIPTION
When trying this out against freetsa.org, I got the following error:

```
runtime error: makeslice: cap out of range
```

This seems to stem from the buffer allocation if ContentLength = -1. From the net/http docs:

```
ContentLength records the length of the associated content. The
value -1 indicates that the length is unknown.
```

Not sure why working with freetsa is causing a -1 to be returned, but this changes the behavior to work in either case.