### PR TITLE
ietf-cms: add support for user-supplied signed attributes

### DIFF
--- a/ietf-cms/protocol/protocol.go
+++ b/ietf-cms/protocol/protocol.go
@@ -626,6 +626,11 @@ func NewSignedData(eci EncapsulatedContentInfo) (*SignedData, error) {
 
 // AddSignerInfo adds a SignerInfo to the SignedData.
 func (sd *SignedData) AddSignerInfo(chain []*x509.Certificate, signer crypto.Signer) error {
+	return sd.AddSignerInfoWithAttrs(nil, chain, signer)
+}
+
+// AddSignerInfoWithAttrs adds a SignerInfo to the SignedData, allowing for the caller to supply extra Attributes to sign.
+func (sd *SignedData) AddSignerInfoWithAttrs(attrs []Attribute, chain []*x509.Certificate, signer crypto.Signer) error {
 	// figure out which certificate is associated with signer.
 	pub, err := x509.MarshalPKIXPublicKey(signer.Public())
 	if err != nil {
@@ -712,7 +717,7 @@ func (sd *SignedData) AddSignerInfo(chain []*x509.Certificate, signer crypto.Sig
 	}
 
 	// sort attributes to match required order in marshaled form
-	si.SignedAttrs, err = sortAttributes(stAttr, mdAttr, ctAttr)
+	si.SignedAttrs, err = sortAttributes(append([]Attribute{stAttr, mdAttr, ctAttr}, attrs...)...)
 	if err != nil {
 		return err
 	}

--- a/ietf-cms/sign.go
+++ b/ietf-cms/sign.go
@@ -3,6 +3,8 @@ package cms
 import (
 	"crypto"
 	"crypto/x509"
+
+	"github.com/github/smimesign/ietf-cms/protocol"
 )
 
 // Sign creates a CMS SignedData from the content and signs it with signer. At
@@ -46,4 +48,9 @@ func SignDetached(data []byte, chain []*x509.Certificate, signer crypto.Signer) 
 // will also be added to the SignedData.
 func (sd *SignedData) Sign(chain []*x509.Certificate, signer crypto.Signer) error {
 	return sd.psd.AddSignerInfo(chain, signer)
+}
+
+// SignWithAttrs adds a signature with extra signed attributes to the SignedData.
+func (sd *SignedData) SignWithAttrs(attrs protocol.Attributes, chain []*x509.Certificate, signer crypto.Signer) error {
+	return sd.psd.AddSignerInfoWithAttrs(attrs, chain, signer)
 }


### PR DESCRIPTION
Some use cases for CMS (notably the code signatures in Apple signed MachO binaries) require additional attributes to be signed. This change adds a SignWithAttrs method to cms.SignedData that accepts additional signed attributes to include.