### PR TITLE
Update README.md to fix #141 to instruct that building from source needs to have a gcc based c compiler to compile. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can download prebuilt Windows binaries [here](https://github.com/github/smim
 ### Building from source
 
 - Make sure you have the [Go compiler](https://golang.org/dl/) installed.
+- Make sure that you have a gcc compiler setup in your path to compile embedded c in go files. 
 - You'll probably want to put `$GOPATH/bin` on your `$PATH`.
 - Run `go get github.com/github/smimesign`
 


### PR DESCRIPTION
Add step to ensure that gcc compiler is setup for building from source.