### PR TITLE
fix race condition caused by a global var

### DIFF
--- a/ietf-cms/protocol/ber.go
+++ b/ietf-cms/protocol/ber.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 )
 
-var encodeIndent = 0
-
 type asn1Object interface {
 	encodeTo(writer *bytes.Buffer) error
 }
@@ -16,8 +14,6 @@ type asn1Structured struct {
 }
 
 func (s asn1Structured) encodeTo(out *bytes.Buffer) error {
-	//fmt.Printf("%s--> tag: % X\n", strings.Repeat("| ", encodeIndent), s.tagBytes)
-	encodeIndent++
 	inner := new(bytes.Buffer)
 	for _, obj := range s.content {
 		err := obj.encodeTo(inner)
@@ -25,7 +21,6 @@ func (s asn1Structured) encodeTo(out *bytes.Buffer) error {
 			return err
 		}
 	}
-	encodeIndent--
 	out.Write(s.tagBytes)
 	encodeLength(out, inner.Len())
 	out.Write(inner.Bytes())
@@ -106,12 +101,12 @@ func lengthLength(i int) (numBytes int) {
 // added to 0x80. The length is encoded in big endian encoding follow after
 //
 // Examples:
-//  length | byte 1 | bytes n
-//  0      | 0x00   | -
-//  120    | 0x78   | -
-//  200    | 0x81   | 0xC8
-//  500    | 0x82   | 0x01 0xF4
 //
+//	length | byte 1 | bytes n
+//	0      | 0x00   | -
+//	120    | 0x78   | -
+//	200    | 0x81   | 0xC8
+//	500    | 0x82   | 0x01 0xF4
 func encodeLength(out *bytes.Buffer, length int) (err error) {
 	if length >= 128 {
 		l := lengthLength(length)


### PR DESCRIPTION
Fixes a race condition caused by a hanging global var. From what I see it's not used anywhere (only in the commented debug log)